### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,12 +89,12 @@ List scaffold = [
 
 dependencies {
     compile spring_boot,swagger,logger,jaxb,jackson,scaffold
-    compile ('org.fisco-bcos.java-sdk:fisco-bcos-java-sdk:3.3.0-SNAPSHOT') {
+    compile ('org.fisco-bcos.java-sdk:fisco-bcos-java-sdk') {
         exclude group: "org.slf4j"
     }
     // support guomi/ecdsa same time, support solcJ-0.5.2
     compile 'org.fisco-bcos:solcJ:0.4.25-rc1'
-    compile('org.fisco-bcos.code-generator:bcos-code-generator:1.0.0-SNAPSHOT') {
+    compile('org.fisco-bcos.code-generator:bcos-code-generator') {
         exclude group: "org.fisco-bcos.java-sdk"
         exclude group: "org.slf4j"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -89,12 +89,12 @@ List scaffold = [
 
 dependencies {
     compile spring_boot,swagger,logger,jaxb,jackson,scaffold
-    compile ('org.fisco-bcos.java-sdk:fisco-bcos-java-sdk') {
+    compile ('org.fisco-bcos.java-sdk:fisco-bcos-java-sdk:3.3.0') {
         exclude group: "org.slf4j"
     }
     // support guomi/ecdsa same time, support solcJ-0.5.2
     compile 'org.fisco-bcos:solcJ:0.4.25-rc1'
-    compile('org.fisco-bcos.code-generator:bcos-code-generator') {
+    compile('org.fisco-bcos.code-generator:bcos-code-generator:1.0.0') {
         exclude group: "org.fisco-bcos.java-sdk"
         exclude group: "org.slf4j"
     }


### PR DESCRIPTION
依赖“org.fisco-bcos.code-generator:bcos-code-generator:1.0.0-SNAPSHOT”和'org.fisco-bcos.java-sdk:fisco-bcos-java-sdk:3.3.0-SNAPSHOT'已失效，需要更新为正式版