### PR TITLE
bugfix: 前置服务“操作动态群组的状态”接口无法停用群组1

### DIFF
--- a/src/main/java/com/webank/webase/front/web3api/Web3ApiService.java
+++ b/src/main/java/com/webank/webase/front/web3api/Web3ApiService.java
@@ -799,15 +799,7 @@ public class Web3ApiService {
      */
     public Client getWeb3j() {
         this.checkConnection();
-        Set<Integer> groupIdSet = bcosSDK.getGroupManagerService().getGroupList(); //1
-        if (groupIdSet.isEmpty()) {
-            log.error("web3jMap is empty, groupList empty! please check your node status");
-            // get default web3j of integer max value
-            return rpcWeb3j;
-        }
-        // get random index to get web3j
-        Integer index = groupIdSet.iterator().next();
-        return bcosSDK.getClient(index);
+        return rpcWeb3j;
     }
 
     /**


### PR DESCRIPTION
接口调用的bcosSDK.getGroupManagerService().getGroupList();方法可能缓存策略有问题，stop的群组依然存在。