### PR TITLE
bugfix: 操作动态群组的状态 接口异常

### DIFF
--- a/src/main/java/com/webank/webase/front/web3api/Web3ApiService.java
+++ b/src/main/java/com/webank/webase/front/web3api/Web3ApiService.java
@@ -800,14 +800,26 @@ public class Web3ApiService {
     public Client getWeb3j() {
         this.checkConnection();
         Set<Integer> groupIdSet = bcosSDK.getGroupManagerService().getGroupList(); //1
+        log.info("getWeb3j groupIdSet get {}", groupIdSet);
         if (groupIdSet.isEmpty()) {
             log.error("web3jMap is empty, groupList empty! please check your node status");
             // get default web3j of integer max value
             return rpcWeb3j;
         }
         // get random index to get web3j
-        Integer index = groupIdSet.iterator().next();
-        return bcosSDK.getClient(index);
+        Client client = null;
+        for (Integer groupId : groupIdSet) {
+            try {
+                client = bcosSDK.getClient(groupId);
+            } catch (BcosSDKException ex) {
+                log.error("getClient failed groupId:{}, ex", groupId, ex);
+            }
+            if (client != null) {
+                return client;
+            }
+        }
+        log.warn("getWeb3j finally get null, now return rpcWeb3j");
+        return rpcWeb3j;
     }
 
     /**


### PR DESCRIPTION
调用“操作动态群组的状态”接口，停止group1的时候获取的org.fisco.bcos.sdk.client失效，由于该连接的缓存问题会进一步影响到前置服务与底链通信的所有接口。最终造成前置与底链无法通信。